### PR TITLE
Update how-to-connect-password-hash-synchronization.md: Add a edge case fix

### DIFF
--- a/articles/active-directory/hybrid/connect/how-to-connect-password-hash-synchronization.md
+++ b/articles/active-directory/hybrid/connect/how-to-connect-password-hash-synchronization.md
@@ -152,6 +152,8 @@ To support temporary passwords in Azure AD for synchronized users, you can enabl
 > If the user has the option "Password never expires" set in Active Directory (AD), the force password change flag will not be set in Active Directory (AD), so the user will not be prompted to change the password during the next sign-in.
 >
 > A new user created in Active Directory with "User must change password at next logon" flag will always be provisioned in Azure AD with a password policy to "Force change password on next sign-in", irrespective of the *ForcePasswordChangeOnLogOn* feature being true or false. This is an Azure AD internal logic since the new user is provisioned without a password, whereas *ForcePasswordChangeOnLogOn* feature only affects admin password reset scenarios.
+>
+> If a user was created in Active Directory with "User must change password at next logon" before the feature was enabled, the user will receive an error while signing in. To remediate this issue, un-check and re-check the field "User must change password at next logon" in Active Directory Users and Computers. After synchronizing the user object changes, the user will receive the expected prompt in Azure AD to update their password. 
 
 > [!CAUTION]
 > You should only use this feature when SSPR and Password Writeback are enabled on the tenant.  This is so that if a user changes their password via SSPR, it will be synchronized to Active Directory.


### PR DESCRIPTION
In two separate organizations, the following behaviour could be observed:

- Azure AD Connect current version
- ForcePasswordChangeOnLogOn set to false initially
- (PHS in staging mode for one group) - should not be relevant

Steps to recreate problem:

1. Create a new user account in AD (test user 1), set an initial password and check "User must change password at next logon"
2. Delta Sync
3. Enable the feature ForcePasswordChangeOnLogOn
4. Delta Sync
5. When trying to sign in in AAD, user will receive an error that they entered a wrong password, when trying sign in locally against DC, user is asked to update their password
6. Creating a second test user *after* the feature was enabled with same properties (initial password, "User must change password at next logon")
7. Delta Sync
8. When trying to sign in in AAD with second test user, flow works as expected and user is forced to update their password
9. Un-check "User must change password at next logon" for test user 1, click OK and re-check it, click OK in DSA.msc
10. Delta Sync
11. Now also test user 1 works the same way as test user 2, is forced to update their password

It is an edge case but one that can certainly apply for different customers